### PR TITLE
Fix dependency injection config name

### DIFF
--- a/src/Dinex.WebApi/Configuration/DependencyInjectionConfig.cs
+++ b/src/Dinex.WebApi/Configuration/DependencyInjectionConfig.cs
@@ -2,10 +2,9 @@
 
 namespace Dinex.Backend.WebApi.Configuration
 {
-    public static class DependecyInjectionConfig
+    public static class DependencyInjectionConfig
     {
-
-        public static IServiceCollection RegisterAllDepdencies(this IServiceCollection services)
+        public static IServiceCollection RegisterAllDependencies(this IServiceCollection services)
         {
             #region swagger
             services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();

--- a/src/Dinex.WebApi/Program.cs
+++ b/src/Dinex.WebApi/Program.cs
@@ -9,7 +9,7 @@ builder.Services.AddApiConfig(builder.Configuration);
 
 builder.Services.AddSwaggerConfiguration();
 
-builder.Services.RegisterAllDepdencies();
+builder.Services.RegisterAllDependencies();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- rename `DependecyInjectionConfig` to `DependencyInjectionConfig`
- rename method `RegisterAllDepdencies` to `RegisterAllDependencies`
- update program to use the new method

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684768729f188322ac0d8cdbf00be465