### PR TITLE
Add encryption verification in user service test

### DIFF
--- a/test/Dinex.Business.Tests/User/UserServiceTests.cs
+++ b/test/Dinex.Business.Tests/User/UserServiceTests.cs
@@ -97,6 +97,9 @@ namespace Dinex.Business.UserTests
             var result = await _userService
                 .CreateAsync(request);
 
+            _cryptographyService.Received(1)
+                .Encrypt(request.UserAccount.Password);
+
             Assert.NotNull(result.Email);
             Assert.NotNull(result.FullName);
             Assert.True(result.Id == userMock.Id);


### PR DESCRIPTION
## Summary
- extend user service test to check password encryption is called

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684769c5d9bc8322911fe82671e9b863