### PR TITLE
Fix enum comment in test

### DIFF
--- a/test/Dinex.Business.Tests/User/UserServiceTests.cs
+++ b/test/Dinex.Business.Tests/User/UserServiceTests.cs
@@ -62,7 +62,7 @@ namespace Dinex.Business.UserTests
                     Password = password,
                     ConfirmPassword = password
                 }
-                //IsActive = UserActivatioStatus.Inactive,
+                //IsActive = AccountActivatioStatus.Inactive,
             };
 
             return request;


### PR DESCRIPTION
## Summary
- correct the enum comment in `UserServiceTests` to reference `AccountActivatioStatus.Inactive`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476a1ab83083229c5a9f30ae033b83